### PR TITLE
POC Pagefind support

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -23,6 +23,9 @@
         "react": "^18.2.0",
         "react-dom": "^18.1.0",
         "sharp": "^0.31.2"
+      },
+      "devDependencies": {
+        "pagefind": "^0.12.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -1186,6 +1189,18 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/algoliasearch": {
@@ -3092,6 +3107,19 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
@@ -4947,6 +4975,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/pagefind": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-0.12.0.tgz",
+      "integrity": "sha512-LHUmlYYweBM6/rK1G+7z2q2WjYeycrB7g5Kuw0w6yMkYztzsEdO2Qj2pJ3z8gsWV8eJsYQyAGOAdqE3SZWlCqA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "bin": {
+        "pagefind": "lib/index.js"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
@@ -5371,6 +5413,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -8326,6 +8374,15 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
+    },
     "algoliasearch": {
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
@@ -9606,6 +9663,16 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "human-signals": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
@@ -10788,6 +10855,16 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "pagefind": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-0.12.0.tgz",
+      "integrity": "sha512-LHUmlYYweBM6/rK1G+7z2q2WjYeycrB7g5Kuw0w6yMkYztzsEdO2Qj2pJ3z8gsWV8eJsYQyAGOAdqE3SZWlCqA==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "parse-entities": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.0.tgz",
@@ -11075,6 +11152,12 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
       "integrity": "sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w=="
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",

--- a/www/package.json
+++ b/www/package.json
@@ -9,7 +9,8 @@
     "check": "astro check && tsc",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "postbuild": "pagefind -v --source dist --bundle-dir en/pagefind"
   },
   "dependencies": {
     "@algolia/client-search": "^4.13.1",
@@ -27,5 +28,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.1.0",
     "sharp": "^0.31.2"
+  },
+  "devDependencies": {
+    "pagefind": "^0.12.0"
   }
 }

--- a/www/src/components/Header/Header.astro
+++ b/www/src/components/Header/Header.astro
@@ -33,10 +33,37 @@ const lang = getLanguageFromURL(currentPage);
 			</a>
 		</div>
 		{KNOWN_LANGUAGE_CODES.length > 1 && <LanguageSelect lang={lang} client:idle />}
-		<!-- <div class="search-item"> -->
+		<div class="search-item">
 			<!-- <Search client:idle /> -->
-		<!-- </div> -->
+			<input id="search" type="text" placeholder="Search...">
+		</div>
 	</nav>
+	<script is:inline>
+  document.querySelector('#search')?.addEventListener('input', async (e) => {
+    // only load the pagefind script once
+    if (e.target.dataset.loaded !== 'true') {
+      e.target.dataset.loaded = 'true'
+      // load the pagefind script
+      window.pagefind = await import("/en/pagefind/pagefind.js");
+    }
+
+    // search the index using the input value
+    const search = await window.pagefind.search(e.target.value)
+
+    // clear the old results
+    document.querySelector('#results').innerHTML = ''
+
+    // add the new results
+    for (const result of search.results) {
+      const data = await result.data()
+      document.querySelector('#results').innerHTML += `
+        <a href="${data.url}">
+          <h3>${data.meta.title}</h3>
+          <p>${data.excerpt}</p>
+        </a>`
+    }
+  })
+</script>
 </header>
 
 <style>

--- a/www/src/components/Header/SkipToContent.astro
+++ b/www/src/components/Header/SkipToContent.astro
@@ -2,7 +2,7 @@
 type Props = {};
 ---
 
-<a href="#article" class="sr-only focus:not-sr-only skiplink"><span>Skip to Content</span></a>
+<a href="#article" data-pagefind-ignore class="sr-only focus:not-sr-only skiplink"><span>Skip to Content</span></a>
 
 <style>
 	.skiplink,

--- a/www/src/layouts/IntroductionLayout.astro
+++ b/www/src/layouts/IntroductionLayout.astro
@@ -143,6 +143,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
 				<p align="center" class="main-logo"> 
 					<Logo className="logo-img" />
 				</p>
+				<div id="results" />
 				<PageContent frontmatter={frontmatter} headings={headings} githubEditUrl={githubEditUrl}>
 					<slot />
 				</PageContent>

--- a/www/src/layouts/MainLayout.astro
+++ b/www/src/layouts/MainLayout.astro
@@ -126,6 +126,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
 				<LeftSidebar currentPage={currentPage} />
 			</aside>
 			<div id="grid-main">
+			    <div id="results" />
 				<PageContent frontmatter={frontmatter} headings={headings} githubEditUrl={githubEditUrl}>
 					<slot />
 				</PageContent>

--- a/www/src/pages/en/pagefind/pagefind.js.ts
+++ b/www/src/pages/en/pagefind/pagefind.js.ts
@@ -1,0 +1,7 @@
+import type { APIContext } from "astro"
+
+export async function get({}: APIContext) {
+  return {
+    body: 'export const search = () => {return {results: []}}'
+  }
+}

--- a/www/src/pages/en/recipes/keys-only-gsi.mdx
+++ b/www/src/pages/en/recipes/keys-only-gsi.mdx
@@ -20,7 +20,7 @@ It is common to define a Global Secondary Index using a `KEYS_ONLY` projection. 
 
 ## Example Setup
 
-<blockQuote>
+<blockQuote data-pagefind-ignore="all">
     <h4>Example Setup</h4>
     <details>
         <summary>Table Definition</summary>

--- a/www/src/partials/entity-query-example-setup.mdx
+++ b/www/src/partials/entity-query-example-setup.mdx
@@ -1,4 +1,4 @@
-<blockQuote>
+<blockQuote data-pagefind-ignore="all">
 <h4>Example Setup</h4>
 <details>
 <summary>Table Definition</summary>

--- a/www/src/partials/table-definition.mdx
+++ b/www/src/partials/table-definition.mdx
@@ -1,4 +1,4 @@
-<blockQuote>
+<blockQuote data-pagefind-ignore="all">
 <h4>Example Setup</h4>
 <details>
 <summary>Table Definition</summary>


### PR DESCRIPTION
A non-production ready POC of adding Pagefind support to the ElectroDB documentation. 

Follows the directions listed [here](https://blog.otterlord.dev/post/astro-search/) for setting up Pagefind.

A quick demo: 
![CleanShot 2023-06-19 at 07 20 22](https://github.com/omair-inam/electrodb/assets/3627923/ab5bae6a-26cc-406f-80a8-a5f3a07c3792)

Limitations:
* Search bar looks janky (no CSS does that to ya)
* Quick-n-dirty inline JS instead of a search component